### PR TITLE
feat: update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,14 @@
-FROM python:3.11-alpine AS builder
+FROM python:3.12-alpine AS builder
 
 WORKDIR /tmp
 COPY ./pyproject.toml ./poetry.lock ./
 
-RUN pip install poetry==1.7.1 && \
-    poetry export -n --without dev -f requirements.txt -o requirements.txt
+RUN set -ex && \
+        python -m pip install --disable-pip-version-check --no-cache-dir poetry==1.8.3 && \
+        poetry self add poetry-plugin-export && \
+        poetry export -n -f requirements.txt -o requirements.txt
 
-FROM python:3.11-alpine
+FROM python:3.12-alpine
 
 WORKDIR /app
 
@@ -15,10 +17,20 @@ COPY --from=builder /tmp/requirements.txt ./
 COPY pyproject.toml README.md ./
 COPY ./project/ ./project/
 
-RUN pip install -r requirements.txt
+RUN set -ex && \
+        addgroup -S nonroot && \
+        adduser -S nonroot -G nonroot && \
+        chown -R nonroot:nonroot /app
+
+RUN set -ex && \
+      python -m pip install --disable-pip-version-check --no-cache-dir -r requirements.txt
 
 # PYTHONPATH hack is needed here because /app contains the "project"
 # module which is referenced in parts of the source code.
 ENV PYTHONPATH=/app
+ENV PYTHONUNBUFFERED=1
 
-CMD ["python", "project/main.py", "server", "--no-reload", "-p", "8080"]
+ENTRYPOINT [ "/usr/local/bin/python", "-m", "uvicorn", "project.server:app" ]
+CMD [ "--host", "0.0.0.0", "--port", "8080", "--workers", "4" ]
+
+USER nonroot


### PR DESCRIPTION
- update Python and Poetry
- ignore pip version check message during build
- drop to unprivileged user inside container
- install packages without caching them
- run uvicorn directly instead of the Python entrypoint script