### PR TITLE
Add entrypoint script for automatic provision of additional certificates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,10 +21,11 @@ COPY ./config/ ./config/
 COPY --from=builder /tmp/requirements.txt ./
 COPY pyproject.toml README.md ./
 COPY ./project/ ./project/
+COPY ./docker-entrypoint.sh ./
 
 RUN set -ex && \
-        addgroup -S nonroot && \
-        adduser -S nonroot -G nonroot && \
+        addgroup nonroot && \
+        adduser nonroot -G nonroot -s /bin/sh -D && \
         chown -R nonroot:nonroot /app
 
 RUN set -ex && \
@@ -35,7 +36,5 @@ RUN set -ex && \
 ENV PYTHONPATH=/app
 ENV PYTHONUNBUFFERED=1
 
-ENTRYPOINT [ "/usr/local/bin/python", "-m", "uvicorn", "project.main:app" ]
+ENTRYPOINT [ "/app/docker-entrypoint.sh" ]
 CMD [ "--host", "0.0.0.0", "--port", "8080", "--workers", "4" ]
-
-USER nonroot

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+
+print_info() {
+    printf "\033[1m[$0] [-]\033[0m %s\n" "$1"
+}
+
+print_error() {
+    printf "\033[31;1m[$0] [!]\033[0m %s\n" "$1"
+}
+
+if [ -n "${FORCE_UPDATE_CA_CERTIFICATES}" ];
+then
+  if [ "$(id -u)" -ne "0" ];
+  then
+    print_error "update-ca-certificates requires to be run as root"
+    exit 1
+  fi
+
+  print_info "Provisioning additional certificates"
+
+  update-ca-certificates
+  rm /etc/ssl/cert.pem
+  ln -s /etc/ssl/certs/ca-certificates.crt /etc/ssl/cert.pem
+fi
+
+if [ "$(id -u)" -eq "0" ];
+then
+  print_info "Dropping privileges"
+  su - nonroot
+fi
+
+print_info "$(printf "%s " "Running server with arguments:" "${@}")"
+exec /usr/local/bin/python -m uvicorn project.main:app "${@}"


### PR DESCRIPTION
One possible proposed solution to the issue raised at https://github.com/PrivateAIM/node-deployment/pull/29.

Certificates would have to be provided at the default path `/usr/local/share/ca-certificates` in PEM format and the container would have to be executed as root, as well as provide an additional environment variable `FORCE_UPDATE_CA_CERTIFICATES`.